### PR TITLE
preview(ci): use CircleCI 2.0 beta

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+
+version: 2
+
+executorType: docker
+
+containerInfo:
+  - image: node:6.9.2
+
+stages:
+  build:
+    workDir: ~/overwire
+
+    steps:
+      - type: checkout
+
+      - type: shell
+        command: npm install
+
+      - type: shell
+        command: ~/overwire/node_modules/.bin/run-s lint:fix test
+        environment:
+          - NODE_ENV: "test"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "istanbul": "^1.1.0-alpha.1",
     "jsdom": "^9.11.0",
     "mocha": "^3.2.0",
+    "npm-run-all": "^4.0.2",
     "rimraf": "^2.5.4",
     "webpack": "^1.14.0"
   }


### PR DESCRIPTION
**⚠️  for preview only – don't merge ⚠️**

I'm thankful to be included in the CircleCI 2.0 beta, and I'm trying it out with Overwire!

### Summary of Changes

- converts `circle.yml` to 2.0 configuration [[docs](https://discuss.circleci.com/t/getting-started-configuration/8088)]
- disables coverage reporting temporarily
- adds `npm-run-all` devDependency to be able to use `run-s` for npm scripts

### TODOs

- [ ] enable coverage reporting